### PR TITLE
Use `struct-field-info-list` instead

### DIFF
--- a/main.rkt
+++ b/main.rkt
@@ -25,19 +25,16 @@
     [(_ the-struct the-instance:expr)
      #:declare the-struct
      (static struct-info? "structure type transformer binding")
-     #:do [(define struct+-len
-             (add1 (string-length (symbol->string (syntax->datum #'the-struct)))))
-           (define si (extract-struct-info (attribute the-struct.value)))]
+     #:do [(define struct-info (extract-struct-info (attribute the-struct.value)))
+           (define field-names (struct-field-info-list (syntax-local-value #'the-struct)))
+           (define field-refs (list-ref struct-info 3))
+           (define field-sets (list-ref struct-info 4))]
      #:with ([field-name field-ref field-set!] ...)
-     (for/list ([field-ref (in-list (list-ref si 3))]
-                [field-set (in-list (list-ref si 4))])
-       (define field-ref-s
-         (symbol->string (syntax->datum field-ref)))
-       (define field-name-s
-         (substring field-ref-s struct+-len))
-       (define field-name
-         (datum->syntax #'the-instance (string->symbol field-name-s)))
-       (list field-name field-ref field-set))
+     (for/list ([field-name (in-list field-names)]
+                [field-ref (in-list field-refs)]
+                [field-set (in-list field-sets)])
+       (define field-name-stx (datum->syntax stx field-name))
+       (list field-name-stx field-ref field-set))
      #:with (field-val-id ...)
      (generate-temporaries #'(field-name ...))
 

--- a/main.rkt
+++ b/main.rkt
@@ -1,40 +1,67 @@
 #lang racket/base
 (require (for-syntax racket/base
+                     racket/function
+                     racket/match
                      racket/struct-info
                      syntax/parse))
 
 (begin-for-syntax
-  (define (make-field-name-transformer instace-id-stx field-ref-stx field-set!-stx)
+  (define (make-field-name-transformer instance-id-stx field-ref-stx field-set!-stx)
     (make-set!-transformer
      (lambda (stx)
-       (syntax-case stx (set!)
+       (syntax-parse stx
+         #:track-literals
          [(set! id v)
           (if (syntax->datum field-set!-stx)
-            (quasisyntax/loc stx
-              (#,field-set!-stx #,instace-id-stx  v))
-            (raise-syntax-error 'set! "field not mutable" stx #'id))]
+              (quasisyntax/loc stx
+                (#,field-set!-stx #,instance-id-stx v))
+              (raise-syntax-error 'set! "field not mutable" stx #'id))]
          [id (identifier? #'id)
              (quasisyntax/loc stx
-               (#,field-ref-stx #,instace-id-stx))]
+               (#,field-ref-stx #,instance-id-stx))]
          [(id . args)
           (quasisyntax/loc stx
-            ((#,field-ref-stx #,instace-id-stx) . args))])))))
+            ((#,field-ref-stx #,instance-id-stx) . args))])))))
+
+(define-for-syntax (stx-transform-name stx transformer)
+  (datum->syntax stx
+                 (string->symbol
+                  (transformer
+                   (symbol->string
+                    (syntax->datum stx))))))
+
+(define-for-syntax (stx-add-prefix prefix separator stx)
+  (match stx
+    [#false #false]
+    [stx (stx-transform-name stx (curry string-append prefix separator))]))
 
 (define-syntax (struct-define stx)
   (syntax-parse stx
-    [(_ the-struct the-instance:expr)
+    [(_ the-struct
+        the-instance:expr
+        (~optional (~seq (~and #:prefix prefix-kw)))
+        (~optional (~seq #:separator separator-kw)))
      #:declare the-struct
      (static struct-info? "structure type transformer binding")
+
      #:do [(define struct-info (extract-struct-info (attribute the-struct.value)))
+           (define instance-name (symbol->string (syntax->datum #'the-instance)))
            (define field-names (struct-field-info-list (syntax-local-value #'the-struct)))
            (define field-refs (list-ref struct-info 3))
-           (define field-sets (list-ref struct-info 4))]
+           (define field-sets (list-ref struct-info 4))
+           (define prefix? (if (attribute prefix-kw) #true #false))
+           (define separator (if (attribute separator-kw) (syntax->datum #'separator-kw) "."))]
+
      #:with ([field-name field-ref field-set!] ...)
      (for/list ([field-name (in-list field-names)]
                 [field-ref (in-list field-refs)]
                 [field-set (in-list field-sets)])
        (define field-name-stx (datum->syntax stx field-name))
-       (list field-name-stx field-ref field-set))
+       (define prefixed-name-stx (stx-add-prefix instance-name separator field-name-stx))
+       (list (if prefix? prefixed-name-stx field-name-stx)
+             field-ref
+             field-set))
+
      #:with (field-val-id ...)
      (generate-temporaries #'(field-name ...))
 
@@ -51,3 +78,23 @@
 
 (provide struct-define
          define-struct-define)
+
+(module+ test
+  (require rackunit)
+  (struct point (x [y #:mutable]) #:transparent)
+  (define p (point 2 3))
+  (check-equal? (let ()
+                  (struct-define point p)
+                  (set! y 6)
+                  (+ x y))
+                8)
+  (check-equal? (let ()
+                  (struct-define point p #:prefix)
+                  (set! p.y 7)
+                  (+ p.x p.y))
+                9)
+  (check-equal? (let ()
+                  (struct-define point p #:prefix #:separator ":")
+                  (set! p:y 2)
+                  (+ p:x p:y))
+                4))


### PR DESCRIPTION
`struct-define` gets a list of field names by taking the list of ref
functions (`point-x`, `point-y`) and cutting out the first part of each
string (`point-`, `point-`), leaving a list of field names (`x`, `y`).

Since `struct-field-info-list` was added in Racket `base` 7.7.0.9,
it's now possible to query the list of field names directly, so I've
converted the code to use that instead.