### PR TITLE
restore backwards-compatibility for expressions

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -2,9 +2,9 @@
 (define collection "struct-define")
 (define deps '("base"))
 (define build-deps '("racket-doc"
+                     "rackunit-lib"
                      "sandbox-lib"
-                     "scribble-lib"
-                     ))
+                     "scribble-lib"))
 (define version "0.1")
 (define pkg-authors '(jeapostrophe))
 (define scribblings '(("struct-define.scrbl" () ("Syntax Extensions"))))

--- a/main.rkt
+++ b/main.rkt
@@ -65,16 +65,16 @@
      #'(define-syntax (the-struct-define stx)
          (syntax-parse stx
            [(_ the-instance:id)
-            #'(the-struct-define the-instance the-instance)]
-           [(_ the-instance:expr the-prefix-id:id)
+            #'(the-struct-define the-instance #:prefix the-instance)]
+           [(_ the-instance:expr #:prefix the-prefix-id:id)
             #'(struct-define the-struct the-instance #:prefix the-prefix-id)]))]
 
     [(_ the-struct-define:id the-struct:id #:prefix #:separator separator-expr:expr)
      #'(define-syntax (the-struct-define stx)
          (syntax-parse stx
            [(_ the-instance:id)
-            #'(the-struct-define the-instance the-instance)]
-           [(_ the-instance:expr the-prefix-id:id)
+            #'(the-struct-define the-instance #:prefix the-instance)]
+           [(_ the-instance:expr #:prefix the-prefix-id:id)
             #'(struct-define the-struct the-instance #:prefix the-prefix-id #:separator separator-expr)]))]))
 
 (provide struct-define

--- a/tests/define-struct-define.rkt
+++ b/tests/define-struct-define.rkt
@@ -32,7 +32,12 @@
     (point-define (point a b))
     (+ x y))
 
+  (define (add-xy-expr-prefix a b)
+    (point-define-dot (point a b) #:prefix p)
+    (+ p.x p.y))
+
   (check-equal? (add-xy-expr 1 2) 3)
+  (check-equal? (add-xy-expr-prefix 1 2) 3)
 
   ;;
   ;; This might be a more practical use of #:prefix

--- a/tests/define-struct-define.rkt
+++ b/tests/define-struct-define.rkt
@@ -5,7 +5,7 @@
            rackunit
            "../main.rkt")
 
-  (struct point (x y) 
+  (struct point (x y)
     #:transparent)
 
   (define-struct-define point-define       point)
@@ -28,16 +28,21 @@
   (check-equal? (add-xy-dot   (point 1 2)) 3)
   (check-equal? (add-xy-colon (point 1 2)) 3)
 
-  ;; 
+  (define (add-xy-expr a b)
+    (point-define (point a b))
+    (+ x y))
+
+  (check-equal? (add-xy-expr 1 2) 3)
+
+  ;;
   ;; This might be a more practical use of #:prefix
   ;;
   (define (dist p q)
     (point-define-dot p)
     (point-define-dot q)
-    (sqrt 
+    (sqrt
       (+ (sqr (- p.x q.x))
          (sqr (- p.y q.y)))))
 
   (check-equal? (dist (point 0 0)
                       (point 3 4)) 5))
-

--- a/tests/struct-define.rkt
+++ b/tests/struct-define.rkt
@@ -4,7 +4,7 @@
   (require rackunit
            "../main.rkt")
 
-  (struct point (x y) 
+  (struct point (x y)
     #:transparent)
 
   (define (add-xy p)
@@ -12,13 +12,18 @@
     (+ x y))
 
   (define (add-xy-dot p)
-    (struct-define point p #:prefix)
+    (struct-define point p #:prefix p)
     (+ p.x p.y))
 
   (define (add-xy-colon p)
-    (struct-define point p #:prefix #:separator ":")
+    (struct-define point p #:prefix p #:separator ":")
     (+ p:x p:y))
+
+  (define (add-xy-expr a b)
+    (struct-define point (point a b))
+    (+ x y))
 
   (check-equal? (add-xy       (point 1 2)) 3)
   (check-equal? (add-xy-dot   (point 1 2)) 3)
-  (check-equal? (add-xy-colon (point 1 2)) 3))
+  (check-equal? (add-xy-colon (point 1 2)) 3)
+  (check-equal? (add-xy-expr 1 2) 3))


### PR DESCRIPTION
Closes #4 while making a slight backwards-incompatible change to @plane's changes: the `struct-define` form with a `#:prefix` now requires that you supply a `prefix-id`. I.e.

```racket
(struct-define foo f #:prefix)
```

becomes

```racket
(struct-define foo f #:prefix g)
```

This is necessary because an expression form like

```racket
(struct-define foo (foo 'a) #:prefix g)
```

can't (shouldn't?) infer a prefix.

The `define-struct-define`-generated syntaxes now infer a prefix when they are given a single id argument, but require an explicit prefix when they're given an expression. I think this gives us the best of both worlds.

cc @plane 