### PR TITLE
Replace syntax/parse import with syntax/parse/pre

### DIFF
--- a/main.rkt
+++ b/main.rkt
@@ -2,7 +2,7 @@
 (require (for-syntax racket/base
                      racket/struct-info
                      racket/syntax
-                     syntax/parse))
+                     syntax/parse/pre))
 
 (begin-for-syntax
   (define (make-field-name-transformer instance-id-stx field-ref-stx field-set!-stx)


### PR DESCRIPTION
This reduces the time to load this module by about 30% on my machine.

Before:

```
~/s/struct-define (master)> time racket -l racket/base -e '(require struct-define)'

________________________________________________________
Executed in  135.63 millis    fish           external
   usr time   91.95 millis    0.08 millis   91.87 millis
   sys time   31.30 millis    1.21 millis   30.09 millis
```

After:

```
~/s/struct-define (master)> time racket -l racket/base -e '(require struct-define)'

________________________________________________________
Executed in  103.12 millis    fish           external
   usr time   66.20 millis    0.07 millis   66.13 millis
   sys time   29.65 millis    1.10 millis   28.55 millis
```